### PR TITLE
Anticipate `nxdomain`s even after resolving

### DIFF
--- a/src/woody_client_thrift_http_transport.erl
+++ b/src/woody_client_thrift_http_transport.erl
@@ -244,6 +244,7 @@ handle_result({error, Reason}, WoodyState) when
     Reason =:= enetunreach;
     Reason =:= ehostunreach;
     Reason =:= eacces;
+    Reason =:= nxdomain;
     element(1, Reason) =:= resolve_failed
 ->
     BinReason = woody_error:format_details(Reason),

--- a/src/woody_client_thrift_v2.erl
+++ b/src/woody_client_thrift_v2.erl
@@ -275,6 +275,7 @@ handle_response({error, Reason}, WoodyState) when
     Reason =:= enetunreach;
     Reason =:= ehostunreach;
     Reason =:= eacces;
+    Reason =:= nxdomain;
     element(1, Reason) =:= resolve_failed
 ->
     BinReason = woody_error:format_details(Reason),


### PR DESCRIPTION
Turns out resolving server endpoint and sending request to this endoint are racy with respect to domain name resolution: for some reason `gen_tcp` resolves literal IP addresses through general DNS mechanism. This means that in the event DNS goes down between resolving step and sending step one could get `{error, nxdomain}` in the second step.

https://github.com/erlang/otp/blob/fc73c903cec66b46caa0afa4785d139092ad0485/lib/kernel/src/inet.erl#L1477-L1483