### PR TITLE
Make `thrift` optional dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -41,6 +41,26 @@
     deprecated_functions_calls,
     deprecated_functions
 ]}.
+{xref_ignores, [
+    {thrift_binary_protocol, new, 2},
+    {thrift_client, call, 3},
+    {thrift_client, close, 1},
+    {thrift_client, new, 2},
+    {thrift_client_codec, read_function_result, 5},
+    {thrift_client_codec, write_function_call, 6},
+    {thrift_membuffer_transport, new, 1},
+    {thrift_processor_codec, match_exception, 3},
+    {thrift_processor_codec, read_function_call, 3},
+    {thrift_processor_codec, write_function_result, 6},
+    {thrift_protocol, close_transport, 1},
+    {thrift_protocol, flush_transport, 1},
+    {thrift_protocol, read, 2},
+    {thrift_protocol, write, 2},
+    {thrift_strict_binary_codec, close, 1},
+    {thrift_strict_binary_codec, new, 0},
+    {thrift_strict_binary_codec, new, 1},
+    {thrift_transport, new, 2}
+]}.
 % at will
 % {xref_warnings, true}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -30,7 +30,6 @@
     {hackney, "1.18.0"},
     {gproc, "0.9.0"},
     {cache, "2.3.3"},
-    {thrift, {git, "https://github.com/valitydev/thrift_erlang.git", {branch, "master"}}},
     {snowflake, {git, "https://github.com/valitydev/snowflake.git", {branch, "master"}}},
     {genlib, {git, "https://github.com/valitydev/genlib.git", {branch, "master"}}}
 ]}.
@@ -80,6 +79,9 @@
         {deps, [
             {cth_readable, "1.4.9"},
             {proper, "1.4.0"},
+            {thrift,
+                {git, "https://github.com/valitydev/thrift_erlang.git",
+                    {ref, "3f3e11246d90aefa8f58b35e4f2eab14c0c28bd2"}}},
             {woody_api_hay,
                 {git, "https://github.com/valitydev/woody_api_hay.git",
                     {ref, "4c39134cddaa9bf6fb8db18e7030ae64f1efb3a9"}}},
@@ -90,7 +92,7 @@
                     {ref, "ebae56fe2b3e79e4eb34afc8cb55c9012ae989f8"}}}
         ]},
         {dialyzer, [
-            {plt_extra_apps, [how_are_you, eunit, proper, common_test, cth_readable]}
+            {plt_extra_apps, [thrift, how_are_you, eunit, proper, common_test, cth_readable]}
         ]}
     ]}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -19,10 +19,6 @@
        {ref,"de159486ef40cec67074afe71882bdc7f7deab72"}},
   0},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.6">>},1},
- {<<"thrift">>,
-  {git,"https://github.com/valitydev/thrift_erlang.git",
-       {ref,"c280ff266ae1c1906fb0dcee8320bb8d8a4a3c75"}},
-  0},
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.7.0">>},1}]}.
 [
 {pkg_hash,[

--- a/src/thrift/include/thrift_constants.hrl
+++ b/src/thrift/include/thrift_constants.hrl
@@ -1,0 +1,62 @@
+%%
+%% Licensed to the Apache Software Foundation (ASF) under one
+%% or more contributor license agreements. See the NOTICE file
+%% distributed with this work for additional information
+%% regarding copyright ownership. The ASF licenses this file
+%% to you under the Apache License, Version 2.0 (the
+%% "License"); you may not use this file except in compliance
+%% with the License. You may obtain a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied. See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+%% TType
+-define(tType_STOP, 0).
+-define(tType_VOID, 1).
+-define(tType_BOOL, 2).
+-define(tType_BYTE, 3).
+-define(tType_I8, 3).
+-define(tType_DOUBLE, 4).
+-define(tType_I16, 6).
+-define(tType_I32, 8).
+-define(tType_I64, 10).
+-define(tType_STRING, 11).
+-define(tType_STRUCT, 12).
+-define(tType_MAP, 13).
+-define(tType_SET, 14).
+-define(tType_LIST, 15).
+
+% TMessageType
+-define(tMessageType_CALL, 1).
+-define(tMessageType_REPLY, 2).
+-define(tMessageType_EXCEPTION, 3).
+-define(tMessageType_ONEWAY, 4).
+
+% TApplicationException
+-define(TApplicationException_Structure,
+        {struct, exception, [{1, undefined, string, undefined, undefined},
+                  {2, undefined, i32, undefined, undefined}]}).
+
+-record('TApplicationException', {message, type}).
+
+-define(TApplicationException_UNKNOWN, 0).
+-define(TApplicationException_UNKNOWN_METHOD, 1).
+-define(TApplicationException_INVALID_MESSAGE_TYPE, 2).
+-define(TApplicationException_WRONG_METHOD_NAME, 3).
+-define(TApplicationException_BAD_SEQUENCE_ID, 4).
+-define(TApplicationException_MISSING_RESULT, 5).
+-define(TApplicationException_INTERNAL_ERROR, 6).
+-define(TApplicationException_PROTOCOL_ERROR, 7).
+-define(TApplicationException_INVALID_TRANSFORM, 8).
+-define(TApplicationException_INVALID_PROTOCOL, 9).
+-define(TApplicationException_UNSUPPORTED_CLIENT_TYPE, 10).
+
+-define (MULTIPLEXED_SERVICE_SEPARATOR, ":").
+-define (MULTIPLEXED_ERROR_HANDLER_KEY, "error_handler").

--- a/src/thrift/include/thrift_protocol.hrl
+++ b/src/thrift/include/thrift_protocol.hrl
@@ -1,0 +1,66 @@
+%%
+%% Licensed to the Apache Software Foundation (ASF) under one
+%% or more contributor license agreements. See the NOTICE file
+%% distributed with this work for additional information
+%% regarding copyright ownership. The ASF licenses this file
+%% to you under the Apache License, Version 2.0 (the
+%% "License"); you may not use this file except in compliance
+%% with the License. You may obtain a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied. See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-ifndef(THRIFT_PROTOCOL_INCLUDED).
+-define(THRIFT_PROTOCOL_INCLUDED, true).
+
+-record(protocol_message_begin, {name, type, seqid}).
+-record(protocol_struct_begin, {name}).
+-record(protocol_field_begin, {name, type, id}).
+-record(protocol_map_begin, {ktype, vtype, size}).
+-record(protocol_list_begin, {etype, size}).
+-record(protocol_set_begin, {etype, size}).
+
+-type tprot_header_val() :: #protocol_message_begin{}
+                          | #protocol_struct_begin{}
+                          | #protocol_field_begin{}
+                          | #protocol_map_begin{}
+                          | #protocol_list_begin{}
+                          | #protocol_set_begin{}
+                          .
+-type tprot_empty_tag() :: message_end
+                         | struct_begin
+                         | struct_end
+                         | field_end
+                         | map_end
+                         | list_end
+                         | set_end
+                         .
+-type tprot_header_tag() :: message_begin
+                          | field_begin
+                          | map_begin
+                          | list_begin
+                          | set_begin
+                          .
+-type tprot_data_tag() :: ui32
+                        | bool
+                        | byte
+                        | i16
+                        | i32
+                        | i64
+                        | double
+                        | string
+                        .
+-type tprot_cont_tag() :: {list, _Type}
+                        | {map, _KType, _VType}
+                        | {set, _Type}
+                        .
+
+
+-endif.

--- a/src/woody.app.src
+++ b/src/woody.app.src
@@ -9,9 +9,11 @@
         genlib,
         cowboy,
         hackney,
-        thrift,
         gproc,
         cache
+    ]},
+    {optional_applications, [
+        thrift
     ]},
     {env, [
         {enable_debug, false}

--- a/src/woody_client_thrift_http_transport.erl
+++ b/src/woody_client_thrift_http_transport.erl
@@ -1,6 +1,6 @@
 -module(woody_client_thrift_http_transport).
 
--behaviour(thrift_transport).
+% -behaviour(thrift_transport).
 
 -dialyzer(no_undefined_callbacks).
 


### PR DESCRIPTION
This should help us reuse Erlang woody code in valitydev/woody_ex Elixir library while also allowing to depend on pinterest/elixir-thrift that happens to have the same application name (`thrift`).