### PR TITLE
Allow to set custom codec in client / server

### DIFF
--- a/src/woody.erl
+++ b/src/woody.erl
@@ -34,10 +34,10 @@
 
 %% Thrift
 -type service_name() :: atom().
--type service() :: {module(), service_name()}.
+-type service() :: {module(), service_name()} | any().
 -type context() :: woody_context:ctx().
 -type func() :: atom().
--type args() :: tuple().
+-type args() :: tuple() | any().
 -type request() :: {service(), func(), args()}.
 -type result() :: _.
 -type th_handler() :: {service(), handler(options())}.

--- a/src/woody_client_codec.erl
+++ b/src/woody_client_codec.erl
@@ -1,0 +1,81 @@
+-module(woody_client_codec).
+
+-type codec() :: module().
+
+-export_type([codec/0]).
+
+-export([get_service_name/2]).
+-export([get_rpc_type/3]).
+
+-export([write_call/6]).
+-export([read_result/5]).
+
+-type buffer() :: iodata().
+-type service() :: woody:service().
+-type func() :: woody:func().
+-type args() :: woody:args().
+-type seqid() :: non_neg_integer().
+
+-type result() ::
+    ok
+    | {reply, woody:result()}
+    | {exception, woody:result()}.
+
+-callback get_service_name(service()) ->
+    woody:service_name().
+
+-callback get_rpc_type(service(), func()) ->
+    woody:rpc_type().
+
+-callback write_call(buffer(), service(), func(), args(), seqid()) ->
+    {ok, buffer()}
+    | {error, _Reason}.
+
+-callback read_result(buffer(), service(), func(), seqid()) ->
+    {ok, result(), _Rest :: buffer()}
+    | {error, _Reason}.
+
+%%
+
+-spec get_service_name(codec(), service()) ->
+    woody:service_name().
+get_service_name(thrift_client_codec, {_Module, Service}) ->
+    Service;
+get_service_name(Codec, Service) ->
+    Codec:get_service_name(Service).
+
+-spec get_rpc_type(codec(), service(), func()) ->
+    woody:rpc_type().
+get_rpc_type(thrift_client_codec, Service, Function) ->
+    woody_util:get_rpc_type(Service, Function);
+get_rpc_type(Codec, Service, Function) ->
+    Codec:get_rpc_type(Service, Function).
+
+-spec write_call(codec(), buffer(), service(), func(), args(), seqid()) ->
+    {ok, buffer()}
+    | {error, _Reason}.
+write_call(thrift_client_codec, Buffer, Service, Function, Args, SeqId) ->
+    thrift_client_codec:write_function_call(
+        Buffer,
+        thrift_strict_binary_codec,
+        Service,
+        Function,
+        Args,
+        SeqId
+    );
+write_call(Codec, Buffer, Service, Function, Args, SeqId) ->
+    Codec:write_call(Buffer, Service, Function, Args, SeqId).
+
+-spec read_result(codec(), buffer(), service(), func(), seqid()) ->
+    {ok, result(), _Rest :: buffer()}
+    | {error, _Reason}.
+read_result(thrift_client_codec, Buffer, Service, Function, SeqId) ->
+    thrift_client_codec:read_function_result(
+        Buffer,
+        thrift_strict_binary_codec,
+        Service,
+        Function,
+        SeqId
+    );
+read_result(Codec, Buffer, Service, Function, SeqId) ->
+    Codec:read_result(Buffer, Service, Function, SeqId).

--- a/src/woody_server_codec.erl
+++ b/src/woody_server_codec.erl
@@ -1,0 +1,104 @@
+-module(woody_server_codec).
+
+-type codec() :: module().
+
+-export_type([codec/0]).
+-export_type([invocation/0]).
+
+-export([get_service_name/2]).
+
+-export([read_call/3]).
+-export([write_result/6]).
+
+-export([catch_business_exception/4]).
+
+-type buffer() :: iodata().
+-type service() :: woody:service().
+-type func() :: woody:func().
+-type args() :: woody:args().
+-type seqid() :: non_neg_integer().
+
+-type invocation() :: {woody:rpc_type(), func(), args()}.
+
+-type result() ::
+    ok
+    | {reply, woody:result()}
+    | {exception, _Name, woody:result()}.
+
+-callback get_service_name(service()) ->
+    woody:service_name().
+
+-callback read_call(buffer(), service()) ->
+    {ok, seqid(), invocation(), _Rest :: buffer()}
+    | {error, _Reason}.
+
+-callback write_result(buffer(), service(), func(), result(), seqid()) ->
+    {ok, buffer()}
+    | {error, _Reason}.
+
+%%
+
+-spec get_service_name(codec(), service()) ->
+    woody:service_name().
+get_service_name(thrift_processor_codec, {_Module, Service}) ->
+    Service;
+get_service_name(Codec, Service) ->
+    Codec:get_service_name(Service).
+
+-spec read_call(codec(), buffer(), service()) ->
+    {ok, seqid(), invocation(), _Rest :: buffer()}
+    | {error, _Reason}.
+read_call(thrift_processor_codec, Buffer, Service) ->
+    case thrift_processor_codec:read_function_call(Buffer, thrift_strict_binary_codec, Service) of
+        {ok, SeqId, {Type, Function, Args}, Rest} ->
+            RpcType = maps:get(Type, #{call => call, oneway => cast}),
+            {ok, SeqId, {RpcType, Function, Args}, Rest};
+        {error, _} = Error ->
+            Error
+    end;
+read_call(Codec, Buffer, Service) ->
+    Codec:read_call(Buffer, Service).
+
+-spec write_result(codec(), buffer(), service(), func(), result(), seqid()) ->
+    {ok, buffer()}
+    | {error, _Reason}.
+write_result(thrift_processor_codec, Buffer, Service, Function, {exception, _Name, {Type, Exception}}, SeqId) ->
+    thrift_processor_codec:write_function_result(
+        Buffer,
+        thrift_strict_binary_codec,
+        Service,
+        Function,
+        {exception, Type, Exception},
+        SeqId
+    );
+write_result(thrift_processor_codec, Buffer, Service, Function, Res, SeqId) ->
+    thrift_processor_codec:write_function_result(
+        Buffer,
+        thrift_strict_binary_codec,
+        Service,
+        Function,
+        Res,
+        SeqId
+    );
+write_result(Codec, Buffer, Service, Function, Res, SeqId) ->
+    Codec:write_result(Buffer, Service, Function, Res, SeqId).
+
+-spec catch_business_exception(codec(), service(), func(), _Exception) ->
+    {exception, _Name :: atom(), _TypedException}
+    | {error, _Reason}.
+catch_business_exception(thrift_processor_codec, Service, Function, Exception) ->
+    case thrift_processor_codec:match_exception(Service, Function, Exception) of
+        {ok, Type} ->
+            {exception, get_exception_name(Type, Exception), {Type, Exception}};
+        {error, _} = Error ->
+            Error
+    end;
+catch_business_exception(_Codec, _Service, _Function, _Exception) ->
+    {error, noimpl}.
+
+-spec get_exception_name(_Type, woody:result()) ->
+    atom().
+get_exception_name({{struct, exception, {_Mod, Name}}, _}, _) ->
+    Name;
+get_exception_name(_Type, Exception) ->
+    element(1, Exception).

--- a/src/woody_server_thrift_handler.erl
+++ b/src/woody_server_thrift_handler.erl
@@ -84,7 +84,7 @@ invoke_handler(State) ->
     handle_result(Result, Reply, MsgType).
 
 -spec handle_function(woody:handler(woody:options()), woody:func(), woody:args(), woody_state:st()) ->
-    {ok, woody:result()} | no_return().
+    {ok, woody:result()} | {exception, _TypeName, woody:result()} | no_return().
 handle_function(Handler, Function, Args, WoodyState) ->
     _ = woody_event_handler:handle_event(?EV_INVOKE_SERVICE_HANDLER, WoodyState, #{}),
     {Module, Opts} = woody_util:get_mod_opts(Handler),


### PR DESCRIPTION
Which is reponsible for:
* (de)serializing requests / responses
* providing request / response metadata for events

Also permit wider service / args models depending on chosen server / client codecs.

Backport #22.